### PR TITLE
ref(*): replace centos with alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM centos:latest
+FROM gliderlabs/alpine:3.1
 
+RUN apk-install python
 ADD . /app
 WORKDIR /app
 CMD python -m SimpleHTTPServer 5000


### PR DESCRIPTION
```
deis/example-dockerfile-python      alpine        aedc8917efff        4 seconds ago       41.2 MB
deis/example-dockerfile-python      latest        833b50d414e1        8 days ago           210 MB
```
